### PR TITLE
Remove the Origin header check in the WS endpoint

### DIFF
--- a/src/webserver.go
+++ b/src/webserver.go
@@ -316,11 +316,6 @@ func WS(w http.ResponseWriter, r *http.Request) {
 
 	var newToken string
 
-	if r.Header.Get("Origin") != "http://"+r.Host {
-		httpStatusError(w, r, 403)
-		return
-	}
-
 	conn, err := websocket.Upgrade(w, r, w.Header(), 1024, 1024)
 	if err != nil {
 		ShowError(err, 0)


### PR DESCRIPTION
Not sure why this check is here: it cannot be a "security" feature (the headers are added/controlled by the client) and it prevent using xteve behind a proxy (origin is then a FQDN)