### PR TITLE
feat: Adds dependencies as go modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,15 +126,9 @@ When the branch is changed, an update is only performed if there is a new versio
 
 #### Build
 1. Download source code
-2. Install dependencies
+2. Build xTeVe (make sure git is installed)
 ```
-go get github.com/koron/go-ssdp
-go get github.com/gorilla/websocket
-go get github.com/kardianos/osext
-```
-3. Build xTeVe
-```
-go build xteve.go
+go build
 ```
 
 ---

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/xteve-project/xTeVe
+
+go 1.13
+
+require (
+	github.com/gorilla/websocket v1.4.1
+	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
+	github.com/koron/go-ssdp v0.0.0-20180514024734-4a0ed625a78b
+	golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.13
 require (
 	github.com/gorilla/websocket v1.4.1
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
-	github.com/koron/go-ssdp v0.0.0-20180514024734-4a0ed625a78b
-	golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271 // indirect
+	github.com/koron/go-ssdp v0.0.0-20191105050749-2e1c40ed0b5d
+	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
+github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=
+github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
+github.com/koron/go-ssdp v0.0.0-20180514024734-4a0ed625a78b h1:wxtKgYHEncAU00muMD06dzLiahtGM1eouRNOzVV7tdQ=
+github.com/koron/go-ssdp v0.0.0-20180514024734-4a0ed625a78b/go.mod h1:5Ky9EC2xfoUKUor0Hjgi2BJhCSXJfMOFlmyYrVKGQMk=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271 h1:N66aaryRB3Ax92gH0v3hp1QYZ3zWWCCUR/j8Ifh45Ss=
+golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -2,11 +2,11 @@ github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvK
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
-github.com/koron/go-ssdp v0.0.0-20180514024734-4a0ed625a78b h1:wxtKgYHEncAU00muMD06dzLiahtGM1eouRNOzVV7tdQ=
-github.com/koron/go-ssdp v0.0.0-20180514024734-4a0ed625a78b/go.mod h1:5Ky9EC2xfoUKUor0Hjgi2BJhCSXJfMOFlmyYrVKGQMk=
+github.com/koron/go-ssdp v0.0.0-20191105050749-2e1c40ed0b5d h1:68u9r4wEvL3gYg2jvAOgROwZ3H+Y3hIDk4tbbmIjcYQ=
+github.com/koron/go-ssdp v0.0.0-20191105050749-2e1c40ed0b5d/go.mod h1:5Ky9EC2xfoUKUor0Hjgi2BJhCSXJfMOFlmyYrVKGQMk=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271 h1:N66aaryRB3Ax92gH0v3hp1QYZ3zWWCCUR/j8Ifh45Ss=
-golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa h1:F+8P+gmewFQYRk6JoLQLwjBCTu3mcIURZfNkVweuRKA=
+golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/src/authentication.go
+++ b/src/authentication.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"../src/internal/authentication"
+	"github.com/xteve-project/xTeVe/src/internal/authentication"
 )
 
 func activatedSystemAuthentication() (err error) {

--- a/src/data.go
+++ b/src/data.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"../src/internal/authentication"
+	"github.com/xteve-project/xTeVe/src/internal/authentication"
 )
 
 // Einstellungen ändern (WebUI)

--- a/src/m3u.go
+++ b/src/m3u.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	m3u "../src/internal/m3u-parser"
+	m3u "github.com/xteve-project/xTeVe/src/internal/m3u-parser"
 )
 
 // Playlisten parsen

--- a/src/provider.go
+++ b/src/provider.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	m3u "../src/internal/m3u-parser"
+	m3u "github.com/xteve-project/xTeVe/src/internal/m3u-parser"
 )
 
 // fileType: Welcher Dateityp soll aktualisiert werden (m3u, hdhr, xml) | fileID: Update einer bestimmten Datei (Provider ID)

--- a/src/update.go
+++ b/src/update.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	up2date "../src/internal/up2date/client"
+	up2date "github.com/xteve-project/xTeVe/src/internal/up2date/client"
 
 	"reflect"
 )

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"../src/internal/authentication"
+	"github.com/xteve-project/xTeVe/src/internal/authentication"
 
 	"github.com/gorilla/websocket"
 )

--- a/xteve.go
+++ b/xteve.go
@@ -13,7 +13,7 @@ import (
 	"runtime"
 	"strings"
 
-	"./src"
+	"github.com/xteve-project/xTeVe/src"
 )
 
 // GitHubStruct : GitHub Account. Über diesen Account werden die Updates veröffentlicht


### PR DESCRIPTION
Make use of the new Go dependency manager to install the dependencies (not that dependent on GOPATH anymore). More information:
https://blog.golang.org/using-go-modules

Initialized with:
```
go mod init github.com/xteve-project/xTeVe
go mod tidy
```

Then the relative imports where not working anymore so I googled around and found [a Reddit thread](https://www.reddit.com/r/golang/comments/ah0w1q/modules_and_local_imports/) and went with the solution provided by user rangeCheck.

Now the build is just running `go build` and everything works as expected!
The dependencies are versioned now so it should rule out any dependency skew on the userside.

I am no Golang expert at all but I was building my personal Docker image and thought, this build process could be simpler right? So down the rabbithole I went ;)