### PR TITLE
Use relative path when posting HTML forms

### DIFF
--- a/html/create-first-user.html
+++ b/html/create-first-user.html
@@ -24,7 +24,7 @@
 
         <div id="content">
 
-            <form id="authentication" action="./" method="post">
+            <form id="authentication" action="" method="post">
 
               <h5>{{.account.username.title}}:</h5>
               <input id="username" type="text" name="username" placeholder="Username" value="">

--- a/html/create-first-user.html
+++ b/html/create-first-user.html
@@ -24,7 +24,7 @@
 
         <div id="content">
 
-            <form id="authentication" action="./web/" method="post">
+            <form id="authentication" action="/web/" method="post">
 
               <h5>{{.account.username.title}}:</h5>
               <input id="username" type="text" name="username" placeholder="Username" value="">

--- a/html/create-first-user.html
+++ b/html/create-first-user.html
@@ -24,7 +24,7 @@
 
         <div id="content">
 
-            <form id="authentication" action="/web/" method="post">
+            <form id="authentication" action="./" method="post">
 
               <h5>{{.account.username.title}}:</h5>
               <input id="username" type="text" name="username" placeholder="Username" value="">

--- a/html/create-first-user.html
+++ b/html/create-first-user.html
@@ -24,7 +24,7 @@
 
         <div id="content">
 
-            <form id="authentication" action="/web/" method="post">
+            <form id="authentication" action="./web/" method="post">
 
               <h5>{{.account.username.title}}:</h5>
               <input id="username" type="text" name="username" placeholder="Username" value="">

--- a/html/login.html
+++ b/html/login.html
@@ -24,7 +24,7 @@
 
         <div id="content">
 
-            <form id="authentication" action="./" method="post">
+            <form id="authentication" action="" method="post">
 
               <h5>{{.login.username.title}}:</h5>
               <input id="username" type="text" name="username" placeholder="Username" value="">

--- a/html/login.html
+++ b/html/login.html
@@ -24,7 +24,7 @@
 
         <div id="content">
 
-            <form id="authentication" action="./web/" method="post">
+            <form id="authentication" action="/web/" method="post">
 
               <h5>{{.login.username.title}}:</h5>
               <input id="username" type="text" name="username" placeholder="Username" value="">

--- a/html/login.html
+++ b/html/login.html
@@ -24,7 +24,7 @@
 
         <div id="content">
 
-            <form id="authentication" action="/web/" method="post">
+            <form id="authentication" action="./web/" method="post">
 
               <h5>{{.login.username.title}}:</h5>
               <input id="username" type="text" name="username" placeholder="Username" value="">

--- a/html/login.html
+++ b/html/login.html
@@ -24,7 +24,7 @@
 
         <div id="content">
 
-            <form id="authentication" action="/web/" method="post">
+            <form id="authentication" action="./" method="post">
 
               <h5>{{.login.username.title}}:</h5>
               <input id="username" type="text" name="username" placeholder="Username" value="">


### PR DESCRIPTION
For making the website work when using a proxy service to redirect for example http://localhost:8080/xteve to http://172.16.0.2:34400/ (for example when running xteve in a docker container and willing to expose the web service via nginx proxy).

Without using relative path, when we open http://localhost:8080/xteve/web and post our username/password, we are redirected to http://localhost/web (wrong port, wrong path), which doesn't work.

This simple fix makes the website work properly when using redirection proxies as well.