### PR TITLE
Correctly unset the category for a channel in XEPG

### DIFF
--- a/ts/menu_ts.ts
+++ b/ts/menu_ts.ts
@@ -1568,7 +1568,7 @@ function openPopUp(dataType, element) {
       // Erweitern der EPG Kategorie
       var dbKey:string = "x-category"
       var text:string[] = ["-", "Kids (Emby only)", "News", "Movie", "Series", "Sports"]
-      var values:string[] = ["-", "Kids", "News", "Movie", "Series", "Sports"]
+      var values:string[] = ["", "Kids", "News", "Movie", "Series", "Sports"]
       var select = content.createSelect(text, values, data[dbKey], dbKey)
       select.setAttribute("onchange", "javascript: this.className = 'changed'")  
       content.appendRow("{{.mapping.epgCategory.title}}", select)


### PR DESCRIPTION
Stores `""` to `x-category` when the category is unset, previosuly `"-"` was stored which would append a `<category>` to each `<programme>` for the channel.

fixes #209