### PR TITLE
Channel update defaults

### DIFF
--- a/src/struct-system.go
+++ b/src/struct-system.go
@@ -266,6 +266,12 @@ type SettingsStruct struct {
 	BufferSize        int      `json:"buffer.size.kb"`
 	BufferTimeout     float64  `json:"buffer.timeout"`
 	CacheImages       bool     `json:"cache.images"`
+
+	ChannelDefaults struct {
+		XUpdateChannelIcon	bool `json:"x-update-channel-icon"`
+		XUpdateChannelName	bool `json:"x-update-channel-name"`
+	} `json:"channelDefaults"`
+
 	EpgSource         string   `json:"epgSource"`
 	FFmpegOptions     string   `json:"ffmpeg.options"`
 	FFmpegPath        string   `json:"ffmpeg.path"`

--- a/src/xepg.go
+++ b/src/xepg.go
@@ -507,6 +507,9 @@ func createXEPGDatabase() (err error) {
 			newChannel.XEPG = xepg
 			newChannel.XChannelID = xChannelID
 
+			newChannel.XUpdateChannelIcon = Settings.ChannelDefaults.XUpdateChannelIcon
+			newChannel.XUpdateChannelName = Settings.ChannelDefaults.XUpdateChannelName
+
 			Data.XEPG.Channels[xepg] = newChannel
 
 		}


### PR DESCRIPTION
#233

Sets `x-update-channel-icon` and `x-update-channel-name` for newly created channels according to `settings.json`:

```
"channelDefaults": {
    "x-update-channel-icon": true,
    "x-update-channel-name": false
  },
```

Defaults to `false`, setting to `true` allows for automated channel creation to change channel name/icon. Ignoring setting will have no effect on normal operation. Does not affect existing channels. 

This is useful because adding new channels in Plex requires user interaction to map them to the TV guide (not sure about Emby or Jellyfin). This allows placeholder channels to be more flexible.
