### PR TITLE
choose default route ip

### DIFF
--- a/src/toolchain.go
+++ b/src/toolchain.go
@@ -295,6 +295,13 @@ func resolveHostIP() (err error) {
 		return
 	}
 
+	conn, err := net.Dial("udp", "1.1.1.1:80")
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+	System.IPAddress = conn.LocalAddr().(*net.UDPAddr).IP.String()
+
 	for _, netInterfaceAddress := range netInterfaceAddresses {
 
 		networkIP, ok := netInterfaceAddress.(*net.IPNet)
@@ -305,13 +312,7 @@ func resolveHostIP() (err error) {
 			var ip = networkIP.IP.String()
 
 			if networkIP.IP.To4() != nil {
-
 				System.IPAddressesV4 = append(System.IPAddressesV4, ip)
-
-				if !networkIP.IP.IsLoopback() && ip[0:7] != "169.254" {
-					System.IPAddress = ip
-				}
-
 			} else {
 				System.IPAddressesV6 = append(System.IPAddressesV6, ip)
 			}


### PR DESCRIPTION
partially fixes #130

makes an intelligent selection of a routable IP as the default.

Poked around the URL code, and I made a branch with a new setting to override the domain used in urls, but it's going to take a bit to unwind the use of setGlobalDomain. I likely did it wrong... but it does work for me.
From what I can tell, on startup System.IPAddress is used, but then it switches to overwriting System.Domain on web requests. Not sure what the right way to handle that is.