### PR TITLE
Fixing epg to use proper channel icon

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module xteve
 go 1.16
 
 require (
-	github.com/gorilla/websocket v1.4.2 // indirect
-	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
-	github.com/koron/go-ssdp v0.0.2 // indirect
+	github.com/gorilla/websocket v1.4.2
+	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
+	github.com/koron/go-ssdp v0.0.2
 )

--- a/src/xepg.go
+++ b/src/xepg.go
@@ -920,7 +920,7 @@ func getPoster(program *Program, xmltvProgram *Program, xepgChannel XEPGChannelS
 
 		if len(xmltvProgram.Poster) == 0 {
 			var poster Poster
-			poster.Src = imgc.Image.GetURL(poster.Src)
+			poster.Src = imgc.Image.GetURL(xepgChannel.TvgLogo)
 			program.Poster = append(program.Poster, poster)
 		}
 


### PR DESCRIPTION
This fixes the channel icon to map to the program poster. This was not using the right url!